### PR TITLE
test Backstage passes item

### DIFF
--- a/Special Rules for Specific Items.md
+++ b/Special Rules for Specific Items.md
@@ -1,0 +1,9 @@
+# Special Rules for Specific Items:
+### 1. Backstage Passes to a TAFKAL80ETC Concert:
+Quality increases as the `SellIn` value approaches:
+ - Increases by 1 when there are more than 10 days remaining.
+ - Increases by 2 when there are 6–10 days remaining.
+ - Increases by 3 when there are 1–5 days remaining.
+
+Once the concert date passes (SellIn <= 0), the Quality drops to 0.
+


### PR DESCRIPTION
1. Backstage Passes to a TAFKAL80ETC Concert:
Quality increases as the `SellIn` value approaches:
 - Increases by 1 when there are more than 10 days remaining.
 - Increases by 2 when there are 6–10 days remaining.
 - Increases by 3 when there are 1–5 days remaining.

Once the concert date passes (SellIn <= 0), the Quality drops to 0.