### PR TITLE
Refactor/implement factory item creation

### DIFF
--- a/src/main/java/com/gildedrose/GildedRose.java
+++ b/src/main/java/com/gildedrose/GildedRose.java
@@ -17,21 +17,12 @@ public class GildedRose {
     private void initializeItemMap() {
         for (Item item : items) {
             String uniqueKey = generateUniqueKey(item);
-            itemMap.put(uniqueKey, createUpdatableItem(item));
+            itemMap.put(uniqueKey, UpdatableItemFactory.createUpdatableItem(item));
         }
     }
 
     private String generateUniqueKey(Item item) {
         return String.format("%s_%d_%d", item.name, item.sellIn, item.quality);
-    }
-
-    private UpdatableItem createUpdatableItem(Item item) {
-        return switch (item.name) {
-            case "Aged Brie" -> new AgedBrie(item);
-            case "Backstage passes to a TAFKAL80ETC concert" -> new BackstagePass(item);
-            case "Sulfuras, Hand of Ragnaros" -> new Sulfuras(item);
-            default -> new StandardItem(item);
-        };
     }
 
     public void updateQuality() {

--- a/src/main/java/com/gildedrose/model/ItemBuilder.java
+++ b/src/main/java/com/gildedrose/model/ItemBuilder.java
@@ -1,0 +1,26 @@
+package com.gildedrose.model;
+
+public class ItemBuilder {
+    private String name;
+    private int sellIn;
+    private int quality;
+
+    public ItemBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ItemBuilder withSellIn(int sellIn) {
+        this.sellIn = sellIn;
+        return this;
+    }
+
+    public ItemBuilder withQuality(int quality) {
+        this.quality = quality;
+        return this;
+    }
+
+    public Item build() {
+        return new Item(name, sellIn, quality);
+    }
+}

--- a/src/main/java/com/gildedrose/model/UpdatableItemFactory.java
+++ b/src/main/java/com/gildedrose/model/UpdatableItemFactory.java
@@ -1,0 +1,20 @@
+package com.gildedrose.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class UpdatableItemFactory {
+    private static final Map<String, Function<Item, UpdatableItem>> ITEM_CREATORS = new HashMap<>();
+
+    static {
+        ITEM_CREATORS.put("Aged Brie", AgedBrie::new);
+        ITEM_CREATORS.put("Backstage passes to a TAFKAL80ETC concert", BackstagePass::new);
+        ITEM_CREATORS.put("Sulfuras, Hand of Ragnaros", Sulfuras::new);
+    }
+
+    public static UpdatableItem createUpdatableItem(Item item) {
+        // If item.name is not in the map, default to StandardItem constructor
+        return ITEM_CREATORS.getOrDefault(item.name, StandardItem::new).apply(item);
+    }
+}

--- a/src/main/java/com/gildedrose/model/UpdatableItemFactory.java
+++ b/src/main/java/com/gildedrose/model/UpdatableItemFactory.java
@@ -1,16 +1,47 @@
 package com.gildedrose.model;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Function;
 
 public class UpdatableItemFactory {
     private static final Map<String, Function<Item, UpdatableItem>> ITEM_CREATORS = new HashMap<>();
 
     static {
-        ITEM_CREATORS.put("Aged Brie", AgedBrie::new);
-        ITEM_CREATORS.put("Backstage passes to a TAFKAL80ETC concert", BackstagePass::new);
-        ITEM_CREATORS.put("Sulfuras, Hand of Ragnaros", Sulfuras::new);
+        loadItemsFromConfig();
+    }
+
+    private static void loadItemsFromConfig() {
+        try (InputStream input = UpdatableItemFactory.class.getClassLoader().getResourceAsStream("items.properties")) {
+            if (input == null) {
+                throw new RuntimeException("items.properties file not found in resources folder.");
+            }
+
+            Properties prop = new Properties();
+            prop.load(input);
+
+            for (String itemName : prop.stringPropertyNames()) {
+                String className = prop.getProperty(itemName);
+                registerItem(itemName, item -> instantiateItem(className, item));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load item configuration", e);
+        }
+    }
+
+    private static UpdatableItem instantiateItem(String className, Item item) {
+        try {
+            Class<?> clazz = Class.forName(className);
+            return (UpdatableItem) clazz.getConstructor(Item.class).newInstance(item);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create item instance for class: " + className, e);
+        }
+    }
+
+    public static void registerItem(String itemName, Function<Item, UpdatableItem> constructor) {
+        ITEM_CREATORS.put(itemName, constructor);
     }
 
     public static UpdatableItem createUpdatableItem(Item item) {

--- a/src/main/resources/items.properties
+++ b/src/main/resources/items.properties
@@ -1,0 +1,3 @@
+Aged\ Brie=com.gildedrose.model.AgedBrie
+Backstage\ passes\ to\ a\ TAFKAL80ETC\ concert=com.gildedrose.model.BackstagePass
+Sulfuras,\ Hand\ of\ Ragnaros=com.gildedrose.model.Sulfuras

--- a/src/test/java/com/gildedrose/GildedRoseTest.java
+++ b/src/test/java/com/gildedrose/GildedRoseTest.java
@@ -1,6 +1,7 @@
 package com.gildedrose;
 
 import com.gildedrose.model.Item;
+import com.gildedrose.model.ItemBuilder;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 
@@ -16,8 +17,8 @@ class GildedRoseTest {
     @DisplayName("Check items name and order after update quality call")
     @Order(0)
     void shouldNotChangeItemNameWhenUpdatingQuality() {
-        Item[] items = new Item[] {
-            new Item("+5 Dexterity Vest", 0, 0),
+            items = new Item[] {
+            new ItemBuilder().withName("+5 Dexterity Vest").withSellIn(0).withQuality(0).build(),
             new Item("Aged Brie", 0, 0),
             new Item("Elixir of the Mongoose", 0, 0),
             new Item("Sulfuras, Hand of Ragnaros", 0, 0),


### PR DESCRIPTION
Implement UpdatableItemFactory and ItemBuilder classes

- Added UpdatableItemFactory to adhere to the Open/Closed Principle, following the application of the Strategy Pattern. The Factory Pattern was introduced to streamline item management and extendability.
- Introduced ItemBuilder to simplify and standardize the creation of Item objects.
***********************
Use Configuration Files for Item Registration
- add items.properties to create new special items
- apdate UpdatableItemFactory class to make the app even more dynamic and maintainable